### PR TITLE
Load lazy lib via requireJS

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -20,14 +20,6 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-<!--    <head>-->
-<!--        <script type="text/javascript" src="Mageplaza_LazyLoading::js/lib/lazy.js"/>-->
-<!--    </head>-->
-    <head>
-        <!--        <script src="Mageplaza_LazyLoading::js/lib/jquery-3.4.1.min.js"/>-->
-        <script src="jquery.js"/>
-        <script src="Mageplaza_LazyLoading::js/lib/jquery.lazy.min.js"/>
-    </head>
     <body>
         <referenceContainer name="after.body.start">
             <block class="Mageplaza\LazyLoading\Block\LazyLoad" name="mplazyload-template" template="Mageplaza_LazyLoading::js.phtml" ifconfig="mplazyload/general/enabled" />

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,0 +1,10 @@
+var config = {
+    map: {
+        '*': {
+            'lazyLoadLib': 'Mageplaza_LazyLoading/js/lib/jquery.lazy.min'
+        }
+    },
+    deps: [
+        'jquery'
+    ]
+};

--- a/view/frontend/templates/js.phtml
+++ b/view/frontend/templates/js.phtml
@@ -21,19 +21,18 @@
 ?>
 <script>
     require([
-        'jquery'
-    ], function ($) {
-        $(document).ready(function () {
-            $('.mplazyload').lazy({
-                threshold: <?= /** @noEscape */ $block->getThreshold() ?>,
-                effect: "fadeIn",
-                effectTime: 1000,
-                afterLoad: function (e) {
-                    e.removeClass('mplazyload-blur');
-                    e.removeClass('mplazyload-icon');
-                    e.removeClass('mplazyload-cms');
-                }
-            });
+        'jquery',
+        'lazyLoadLib'
+    ], function ($, lazy) {
+        $('.mplazyload').lazy({
+            threshold: <?= /** @noEscape */ $block->getThreshold() ?>,
+            effect: "fadeIn",
+            effectTime: 1000,
+            afterLoad: function (e) {
+                e.removeClass('mplazyload-blur');
+                e.removeClass('mplazyload-icon');
+                e.removeClass('mplazyload-cms');
+            }
         });
     });
 </script>


### PR DESCRIPTION
This makes lazy lib to load via requireJS. It fixed issue when unable to load lib with clean cache:
<img width="1552" alt="Secrid Cardprotector - Configurable no opitons" src="https://user-images.githubusercontent.com/62345629/80974857-00b73a00-8e2a-11ea-9b00-c30032d12df0.png">
Also should fix #3 