### PR TITLE
FIX Static Block Widget on CMS pages,  processing  the images multiple times leads to loading failure, Update Filter.php

### DIFF
--- a/Plugin/Model/Template/Filter.php
+++ b/Plugin/Model/Template/Filter.php
@@ -117,6 +117,11 @@ class Filter
                         . '/mageplaza/lazyloading/'
                         . $imgInfo['basename'];
                 }
+                
+                // dont replace twice, in static block widget if they already have been processed and have data-src
+                if (strpos($img, 'data-src="') !== false) {
+                    continue;
+                }
 
                 if (strpos($img, 'class="') !== false) {
                     $newClass = str_replace('class="', 'class="' . $class . ' ', $img);


### PR DESCRIPTION
there is an error if you add an image to a static block and include that static block via the static block widget onto a cms page... it will get processed twice, my fix was just to check for data-src attribute and if it exists just skip it.
